### PR TITLE
Fix starlette dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ pydantic_core==2.14.6
 pyflakes==3.2.0
 sniffio==1.3.0
 soupsieve==2.5
-starlette==0.36.2
 tenacity==8.2.3
 typing_extensions==4.9.0
 urllib3==2.1.0


### PR DESCRIPTION
## Summary
- remove the `starlette==0.36.2` pin from requirements

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684799d81de4832090167b5b8d9e1360